### PR TITLE
Added check for upper case card details

### DIFF
--- a/cardReader.js
+++ b/cardReader.js
@@ -147,6 +147,11 @@ CardReader.prototype.onFoundCard = function(callback) {
   var self = this;
   this.read(function(cardId,onOff){
     var card = self.knownCards[cardId];
+    //if card not found, check for an upper case version
+    if(!card){
+        card = self.knownCards[cardId.toUpperCase()]
+    }
+
     if(card){
       self.winston.log('debug',"Found card belonging to %s",card.username);
       if(callback){


### PR DESCRIPTION
If the card is not found in the initial check, we now check again with
the card in upper case to ensure that it is definitely not in the
approved user list. Not elegant, but should work.

Solution for [issue #2](https://github.com/so-make-it/door-controller/issues/2)
